### PR TITLE
Adopt a system of TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+node_js:
+  - stable
+cache:
+  directories:
+    - dist
+    - node_modules
+jobs:
+  include:
+    - stage: build
+      script: echo "Building app ..."
+      script: npm run gulp:build
+    - stage: deploy
+      if: branch = master
+      script: echo "Deploying to GitHub releases ..."
+      before_deploy:
+        - git config --local user.name "$GIT_CONFIG_NAME"
+        - git config --local user.email "$GIT_CONFIG_EMAIL"
+        - git tag "v$(cat ./src/manifest.json  | jq -r '.version')"
+        - npm run gulp:deploy
+      deploy:
+        provider: releases
+        api_key:
+          secure: AhNzYVwZCCc7HlA2y0O03dQDZvG9wgGeAAB5wdlDd2/VsTXOglhGUxESEG0n7JI2L7iOrj2Y5r77bUpkxTE3aaZbrhkR/g9pBVggQ4WG4GSSJtQ6f9sqGsa0V3HCoNzFhu5hIRwq3gIn1ny/s1SJZgKA9bssFFX7E5zSJd0+SJgcL/gwYYiwEAuOCjqFy08i7D5seeSMCkKhq8Gm7PqjzDwZD/GG5B5uP4M/GMwdLP04XfFS/OXyTaQs/7qi5t8lRnFHIjl7W3Nr8OpmSZDjJ1UQ6uountxz0LcK7rfSj0+v002OWIUnYIIm5G2j558PQW/ogonqJJpJvRbC/TZCeb5YVfberogGTk9kTHOKFAJ0r/5SaySLYcpl0Wm2ELgvH/oqbZgMM/5tQ5cMgxw927W8SiF7F3TKIiKvfTD2EvkMkHdEH/gMuvWDh0Dc1bs+7BPwBZvQkl/Cop8rkDZcEm4l6Vp/Iu43KVt9OPwXBIZL2kfA2eDLbCx0VM3IDqqWt+4FGQ5h43y6hUsEeovh9aT2sn3MUAlcMbF171izKeEgYf6nqvOkl0LOZ6bJZ0RaSjftjsDpFi7HXOyASUdFvR5OFv5d6RaP/tyYIUQWt4mBTPDFVj+o0fJ1e+VThM7WwxHoVIVj+5GN9g3jSzzj3jdn8U6v3w0sf0qPx7F28FU=
+        skip_cleanup: true
+        file: archive.zip
+        on:
+          tags: false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,21 +72,26 @@ gulp.task('manifest', () => {
         .pipe( gulp.dest('./dist'));
 });
 
-gulp.task('clean', () => {
+gulp.task('clean:dist', () => {
     const del = require('del');
-    return del(['./dist', './*.zip'], { force:true });
+    return del('./dist', { force:true });
+});
+
+gulp.task('clean:zip', () => {
+    const del = require('del');
+    return del('./archive.zip', { force:true });
 });
 
 gulp.task('zip', () => {
     const zip = require('gulp-zip');
-    return gulp.src('./dist')
+    return gulp.src('./dist/**/*', { base: '.' })
         .pipe(zip('archive.zip'))
         .pipe(gulp.dest('./'));
 });
 
 gulp.task('build',
     gulp.series(
-        'clean',
+        'clean:dist',
         gulp.parallel(
             'scripts',
             'styles',
@@ -95,7 +100,13 @@ gulp.task('build',
             'images',
             'vendors',
             'manifest'
-        ),
+        )
+    )
+);
+
+gulp.task('deploy',
+    gulp.series(
+        'clean:zip',
         'zip'
     )
 );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,6 +82,13 @@ gulp.task('clean:zip', () => {
     return del('./archive.zip', { force:true });
 });
 
+gulp.task('clean:all',
+    gulp.parallel(
+        'clean:dist',
+        'clean:zip'
+    )
+);
+
 gulp.task('zip', () => {
     const zip = require('gulp-zip');
     return gulp.src('./dist/**/*', { base: '.' })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "eslint:fix": "./node_modules/.bin/eslint --fix ./src/scripts/*.js",
     "gulp:watch": "./node_modules/.bin/gulp watch",
     "gulp:build": "./node_modules/.bin/gulp build",
-    "gulp:clean": "./node_modules/.bin/gulp clean"
+    "gulp:clean": "./node_modules/.bin/gulp clean",
+    "gulp:deploy": "./node_modules/.bin/gulp deploy"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint:fix": "./node_modules/.bin/eslint --fix ./src/scripts/*.js",
     "gulp:watch": "./node_modules/.bin/gulp watch",
     "gulp:build": "./node_modules/.bin/gulp build",
-    "gulp:clean": "./node_modules/.bin/gulp clean",
+    "gulp:clean": "./node_modules/.bin/gulp clean:all",
     "gulp:deploy": "./node_modules/.bin/gulp deploy"
   },
   "repository": {


### PR DESCRIPTION
close #16 

- `issue-12-adapt-a-postcss` からブランチを切ったので #13 を先にマージしてから、こちらのレビューをお願いします。

#### `.travis.yml`

```yml
language: node_js
node_js:
  - stable
cache:
  directories:
    - dist
    - node_modules
jobs:
  include:
    - stage: build
      script: echo "Building app ..."
      script: npm run gulp:build
    - stage: deploy
      if: branch = master
      script: echo "Deploying to GitHub releases ..."
      before_deploy:
        - git config --local user.name "$GIT_CONFIG_NAME"
        - git config --local user.email "$GIT_CONFIG_EMAIL"
        - git tag "v$(cat ./src/manifest.json  | jq -r '.version')"
        - npm run gulp:deploy
      deploy:
        provider: releases
        api_key:
          secure: [secure]
        skip_cleanup: true
        file: archive.zip
        on:
          tags: false
```

#### CIで行われる処理についての説明

- node.js は常に stable バージョンを使用してビルド
- cache の対象はビルド後の`dist/` と npm install で導入した依存ライブラリ `node_modules/`の2つ
- job は `build` と `deploy` の 2ステージ構成
    - `build`
        - `./dist` を作成するタスク `gulp:build` を実行する
    - `deploy`
        - master ブランチに push されたときのみ実行される
        - deploy 前に git config 設定と `./src/manifest.json` の `version` で git tag を打つ
            - ※ 既に存在するバージョンだった場合は git tag の結果が `fatal` して Error 扱いとしてCIが落ちる設計
        - タグが打てたら `gulp:deploy` タスクを実行して `./archive.zip` を生成する
        - deploy タスクで GitHub API 経由で 該当 release の assets に `./archive.zip` をアップロードする

